### PR TITLE
Update composer.lock, package updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,35 +9,35 @@
     "packages": [
         {
             "name": "doctrine/annotations",
-            "version": "v1.2.7",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
+                "reference": "30e07cf03edc3cd3ef579d0dd4dd8c58250799a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/30e07cf03edc3cd3ef579d0dd4dd8c58250799a5",
+                "reference": "30e07cf03edc3cd3ef579d0dd4dd8c58250799a5",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
-                "php": ">=5.3.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^5.6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Annotations\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -73,20 +73,20 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2016-10-24 11:45:47"
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3",
                 "shasum": ""
             },
             "require": {
@@ -143,7 +143,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "doctrine/lexer",
@@ -249,16 +249,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "47b254ea51f1d6d5dc04b9b299e88346bf2369e3"
+                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/47b254ea51f1d6d5dc04b9b299e88346bf2369e3",
-                "reference": "47b254ea51f1d6d5dc04b9b299e88346bf2369e3",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4dd659edadffdc2143e4753df655d866dbfeedf0",
+                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0",
                 "shasum": ""
             },
             "require": {
@@ -296,20 +296,20 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-04-19 13:41:41"
+            "time": "2016-09-16 12:04:44"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.2",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf"
+                "reference": "c0125896dbb151380ab47e96c621741e79623beb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/088c04e2f261c33bed6ca5245491cfca69195ccf",
-                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c0125896dbb151380ab47e96c621741e79623beb",
+                "reference": "c0125896dbb151380ab47e96c621741e79623beb",
                 "shasum": ""
             },
             "require": {
@@ -344,20 +344,20 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-04-03 06:00:07"
+            "time": "2016-10-17 15:23:22"
         },
         {
             "name": "psr/cache",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "9e66031f41fbbdda45ee11e93c45d480ccba3eb3"
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/9e66031f41fbbdda45ee11e93c45d480ccba3eb3",
-                "reference": "9e66031f41fbbdda45ee11e93c45d480ccba3eb3",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
                 "shasum": ""
             },
             "require": {
@@ -390,26 +390,34 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2015-12-11 02:52:07"
+            "time": "2016-08-06 20:24:11"
         },
         {
             "name": "psr/log",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -423,25 +431,26 @@
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "sensio/generator-bundle",
-            "version": "v3.0.7",
+            "version": "v3.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioGeneratorBundle.git",
-                "reference": "d1be460925376703a470a3ac6ec034eb7eab3892"
+                "reference": "b9be7f1b3b2e8bcfc1debefc901b71da923a5e5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/d1be460925376703a470a3ac6ec034eb7eab3892",
-                "reference": "d1be460925376703a470a3ac6ec034eb7eab3892",
+                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/b9be7f1b3b2e8bcfc1debefc901b71da923a5e5c",
+                "reference": "b9be7f1b3b2e8bcfc1debefc901b71da923a5e5c",
                 "shasum": ""
             },
             "require": {
@@ -480,20 +489,20 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2016-06-20 05:58:05"
+            "time": "2016-10-10 14:17:42"
         },
         {
             "name": "symfony/asset",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/asset.git",
-                "reference": "1354ba65bb5054e6311f0338e26f4907c220d1dc"
+                "reference": "967518f63a096593064c26ae1201a76a58caf216"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/asset/zipball/1354ba65bb5054e6311f0338e26f4907c220d1dc",
-                "reference": "1354ba65bb5054e6311f0338e26f4907c220d1dc",
+                "url": "https://api.github.com/repos/symfony/asset/zipball/967518f63a096593064c26ae1201a76a58caf216",
+                "reference": "967518f63a096593064c26ae1201a76a58caf216",
                 "shasum": ""
             },
             "require": {
@@ -535,20 +544,20 @@
             ],
             "description": "Symfony Asset Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-13 18:06:41"
+            "time": "2016-09-24 15:56:48"
         },
         {
             "name": "symfony/cache",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "cf3e5492b0c36167dad4a8e94b3daac449ee9abe"
+                "reference": "a4bf05e93eecf1df96612ad0ccf49e03177b17b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/cf3e5492b0c36167dad4a8e94b3daac449ee9abe",
-                "reference": "cf3e5492b0c36167dad4a8e94b3daac449ee9abe",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/a4bf05e93eecf1df96612ad0ccf49e03177b17b4",
+                "reference": "a4bf05e93eecf1df96612ad0ccf49e03177b17b4",
                 "shasum": ""
             },
             "require": {
@@ -601,20 +610,20 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2016-06-29 05:42:25"
+            "time": "2016-09-25 08:27:07"
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "0d0ac77c336eb73f35bebdf3e1f3695ac741bbc9"
+                "reference": "bcb072aba46ddf3b1a496438c63be6be647739aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/0d0ac77c336eb73f35bebdf3e1f3695ac741bbc9",
-                "reference": "0d0ac77c336eb73f35bebdf3e1f3695ac741bbc9",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/bcb072aba46ddf3b1a496438c63be6be647739aa",
+                "reference": "bcb072aba46ddf3b1a496438c63be6be647739aa",
                 "shasum": ""
             },
             "require": {
@@ -657,20 +666,20 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-09-06 23:30:54"
         },
         {
             "name": "symfony/config",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "bcf5aebabc95b56e370e13d78565f74c7d8726dc"
+                "reference": "949e7e846743a7f9e46dc50eb639d5fde1f53341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/bcf5aebabc95b56e370e13d78565f74c7d8726dc",
-                "reference": "bcf5aebabc95b56e370e13d78565f74c7d8726dc",
+                "url": "https://api.github.com/repos/symfony/config/zipball/949e7e846743a7f9e46dc50eb639d5fde1f53341",
+                "reference": "949e7e846743a7f9e46dc50eb639d5fde1f53341",
                 "shasum": ""
             },
             "require": {
@@ -710,24 +719,25 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-09-25 08:27:07"
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "747154aa69b0f83cd02fc9aa554836dee417631a"
+                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/747154aa69b0f83cd02fc9aa554836dee417631a",
-                "reference": "747154aa69b0f83cd02fc9aa554836dee417631a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c99da1119ae61e15de0e4829196b9fba6f73d065",
+                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
+                "symfony/debug": "~2.8|~3.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
@@ -770,20 +780,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 07:02:31"
+            "time": "2016-10-06 01:44:51"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "06e2d52e307ef880ac739f44ee6c2418ca9e3283"
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/06e2d52e307ef880ac739f44ee6c2418ca9e3283",
-                "reference": "06e2d52e307ef880ac739f44ee6c2418ca9e3283",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
                 "shasum": ""
             },
             "require": {
@@ -827,20 +837,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-09-06 11:02:40"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "b7272b65f2f46cbe77def7d33916f2613669c508"
+                "reference": "c578891216090069cd6d2e573402e13e39b3ad5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b7272b65f2f46cbe77def7d33916f2613669c508",
-                "reference": "b7272b65f2f46cbe77def7d33916f2613669c508",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/c578891216090069cd6d2e573402e13e39b3ad5c",
+                "reference": "c578891216090069cd6d2e573402e13e39b3ad5c",
                 "shasum": ""
             },
             "require": {
@@ -849,7 +859,7 @@
             "require-dev": {
                 "symfony/config": "~2.8|~3.0",
                 "symfony/expression-language": "~2.8|~3.0",
-                "symfony/yaml": "~2.8|~3.0"
+                "symfony/yaml": "~2.8.7|~3.0.7|~3.1.1|~3.2"
             },
             "suggest": {
                 "symfony/config": "",
@@ -887,20 +897,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:42:25"
+            "time": "2016-10-24 15:52:44"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5"
+                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7f9839ede2070f53e7e2f0849b9bd14748c434c5",
-                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
+                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
                 "shasum": ""
             },
             "require": {
@@ -947,20 +957,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-10-13 06:28:43"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "322da5f0910d8aa0b25fa65ffccaba68dbddb890"
+                "reference": "0565b61bf098cb4dc09f4f103f033138ae4f42c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/322da5f0910d8aa0b25fa65ffccaba68dbddb890",
-                "reference": "322da5f0910d8aa0b25fa65ffccaba68dbddb890",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0565b61bf098cb4dc09f4f103f033138ae4f42c6",
+                "reference": "0565b61bf098cb4dc09f4f103f033138ae4f42c6",
                 "shasum": ""
             },
             "require": {
@@ -996,20 +1006,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-10-18 04:30:12"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7"
+                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8201978de88a9fa0923e18601bb17f1df9c721e7",
-                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
+                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
                 "shasum": ""
             },
             "require": {
@@ -1045,20 +1055,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-09-28 00:11:12"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "8515a108e51c2a06b1ac96fdd7d9c23b651dd25f"
+                "reference": "9f4cb23e6ef2e4def3ad666c15ea784353c07cb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/8515a108e51c2a06b1ac96fdd7d9c23b651dd25f",
-                "reference": "8515a108e51c2a06b1ac96fdd7d9c23b651dd25f",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/9f4cb23e6ef2e4def3ad666c15ea784353c07cb0",
+                "reference": "9f4cb23e6ef2e4def3ad666c15ea784353c07cb0",
                 "shasum": ""
             },
             "require": {
@@ -1084,7 +1094,8 @@
                 "symfony/translation": "~2.8|~3.0"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "<3.0"
+                "phpdocumentor/reflection-docblock": "<3.0",
+                "phpdocumentor/type-resolver": "<0.2.0"
             },
             "require-dev": {
                 "phpdocumentor/reflection-docblock": "^3.0",
@@ -1143,20 +1154,20 @@
             ],
             "description": "Symfony FrameworkBundle",
             "homepage": "https://symfony.com",
-            "time": "2016-06-30 09:40:26"
+            "time": "2016-10-23 01:13:38"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "6b5a3764c5b0ce1f0ec3b8be5bba969122a78cfc"
+                "reference": "f21e5a8b88274b7720779aa88f9c02c6d6ec08d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6b5a3764c5b0ce1f0ec3b8be5bba969122a78cfc",
-                "reference": "6b5a3764c5b0ce1f0ec3b8be5bba969122a78cfc",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f21e5a8b88274b7720779aa88f9c02c6d6ec08d7",
+                "reference": "f21e5a8b88274b7720779aa88f9c02c6d6ec08d7",
                 "shasum": ""
             },
             "require": {
@@ -1196,20 +1207,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 07:02:31"
+            "time": "2016-10-24 15:52:44"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "3a1ce1829128988826739bd9dd820f3238b92d65"
+                "reference": "c235f1b13ba67012e283996a5427f22e2e04be14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3a1ce1829128988826739bd9dd820f3238b92d65",
-                "reference": "3a1ce1829128988826739bd9dd820f3238b92d65",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c235f1b13ba67012e283996a5427f22e2e04be14",
+                "reference": "c235f1b13ba67012e283996a5427f22e2e04be14",
                 "shasum": ""
             },
             "require": {
@@ -1217,7 +1228,7 @@
                 "psr/log": "~1.0",
                 "symfony/debug": "~2.8|~3.0",
                 "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/http-foundation": "~2.8.8|~3.0.8|~3.1.2|~3.2"
+                "symfony/http-foundation": "~2.8.13|~3.1.6|~3.2"
             },
             "conflict": {
                 "symfony/config": "<2.8"
@@ -1278,7 +1289,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-30 17:16:01"
+            "time": "2016-10-27 02:38:31"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1508,16 +1519,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "5c11a1a4d4016662eeaf0f8757958c7de069f9a0"
+                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/5c11a1a4d4016662eeaf0f8757958c7de069f9a0",
-                "reference": "5c11a1a4d4016662eeaf0f8757958c7de069f9a0",
+                "url": "https://api.github.com/repos/symfony/process/zipball/66de154ae86b1a07001da9fbffd620206e4faf94",
+                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94",
                 "shasum": ""
             },
             "require": {
@@ -1553,20 +1564,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:42:25"
+            "time": "2016-09-29 14:13:09"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "22c7adc204057a0ff0b12eea2889782a5deb70a3"
+                "reference": "8edf62498a1a4c57ba317664a4b698339c10cdf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/22c7adc204057a0ff0b12eea2889782a5deb70a3",
-                "reference": "22c7adc204057a0ff0b12eea2889782a5deb70a3",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/8edf62498a1a4c57ba317664a4b698339c10cdf6",
+                "reference": "8edf62498a1a4c57ba317664a4b698339c10cdf6",
                 "shasum": ""
             },
             "require": {
@@ -1628,20 +1639,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-08-16 14:58:24"
         },
         {
             "name": "symfony/security-core",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "8a17287ca4b2a8fe45414a8bbb80db139d503251"
+                "reference": "665259f6d2f826a21e75ee2e8e3ef24bd9a46e13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/8a17287ca4b2a8fe45414a8bbb80db139d503251",
-                "reference": "8a17287ca4b2a8fe45414a8bbb80db139d503251",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/665259f6d2f826a21e75ee2e8e3ef24bd9a46e13",
+                "reference": "665259f6d2f826a21e75ee2e8e3ef24bd9a46e13",
                 "shasum": ""
             },
             "require": {
@@ -1694,20 +1705,20 @@
             ],
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 15:24:22"
+            "time": "2016-10-06 01:44:51"
         },
         {
             "name": "symfony/security-csrf",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-csrf.git",
-                "reference": "94057944fb53ad1f38c3633c8bca388d7d1864ba"
+                "reference": "74c6156851615ba3efa82074d891856481dadf0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/94057944fb53ad1f38c3633c8bca388d7d1864ba",
-                "reference": "94057944fb53ad1f38c3633c8bca388d7d1864ba",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/74c6156851615ba3efa82074d891856481dadf0e",
+                "reference": "74c6156851615ba3efa82074d891856481dadf0e",
                 "shasum": ""
             },
             "require": {
@@ -1752,11 +1763,11 @@
             ],
             "description": "Symfony Security Component - CSRF Library",
             "homepage": "https://symfony.com",
-            "time": "2016-03-10 11:16:56"
+            "time": "2016-07-05 11:09:33"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -1805,16 +1816,16 @@
         },
         {
             "name": "symfony/templating",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/templating.git",
-                "reference": "710a9d568d231c84152e055d9b79851a6fff099c"
+                "reference": "619e1dafc0e014d18492f5ba5722ddf17c3a7655"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/templating/zipball/710a9d568d231c84152e055d9b79851a6fff099c",
-                "reference": "710a9d568d231c84152e055d9b79851a6fff099c",
+                "url": "https://api.github.com/repos/symfony/templating/zipball/619e1dafc0e014d18492f5ba5722ddf17c3a7655",
+                "reference": "619e1dafc0e014d18492f5ba5722ddf17c3a7655",
                 "shasum": ""
             },
             "require": {
@@ -1856,20 +1867,20 @@
             ],
             "description": "Symfony Templating Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-27 16:15:51"
+            "time": "2016-09-06 11:02:40"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "d63a94528530c3ea5ff46924c8001cec4a398609"
+                "reference": "ff1285087397d2f64041b35e591f3025881c90cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/d63a94528530c3ea5ff46924c8001cec4a398609",
-                "reference": "d63a94528530c3ea5ff46924c8001cec4a398609",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/ff1285087397d2f64041b35e591f3025881c90cd",
+                "reference": "ff1285087397d2f64041b35e591f3025881c90cd",
                 "shasum": ""
             },
             "require": {
@@ -1920,20 +1931,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-10-18 04:30:12"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.2",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de"
+                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/2884c26ce4c1d61aebf423a8b912950fe7c764de",
-                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
                 "shasum": ""
             },
             "require": {
@@ -1969,22 +1980,22 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-10-24 18:41:13"
         }
     ],
     "packages-dev": [
         {
             "name": "beberlei/assert",
-            "version": "v2.5.1",
+            "version": "v2.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/beberlei/assert.git",
-                "reference": "8a9ad22f1220e47a6d174843e8abef08f5eac441"
+                "reference": "f567e3e4bce5419bccb9e9b1faf8d4ca9b2f5055"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/beberlei/assert/zipball/8a9ad22f1220e47a6d174843e8abef08f5eac441",
-                "reference": "8a9ad22f1220e47a6d174843e8abef08f5eac441",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/f567e3e4bce5419bccb9e9b1faf8d4ca9b2f5055",
+                "reference": "f567e3e4bce5419bccb9e9b1faf8d4ca9b2f5055",
                 "shasum": ""
             },
             "require": {
@@ -1992,14 +2003,10 @@
                 "php": ">=5.3"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "2.0.0-alpha",
                 "phpunit/phpunit": "@stable"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "Assert": "lib/"
@@ -2015,7 +2022,13 @@
             "authors": [
                 {
                     "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
                 }
             ],
             "description": "Thin assertion library for input validation in business models.",
@@ -2024,7 +2037,7 @@
                 "assertion",
                 "validation"
             ],
-            "time": "2016-06-20 12:01:28"
+            "time": "2016-10-31 12:09:54"
         },
         {
             "name": "broadway/broadway",
@@ -2032,12 +2045,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/qandidate-labs/broadway.git",
-                "reference": "18d289a0e192faef448a0ea768291637926393b8"
+                "reference": "f973c8ad2a58e65f40d072b898aca55aceb2a597"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qandidate-labs/broadway/zipball/18d289a0e192faef448a0ea768291637926393b8",
-                "reference": "18d289a0e192faef448a0ea768291637926393b8",
+                "url": "https://api.github.com/repos/qandidate-labs/broadway/zipball/f973c8ad2a58e65f40d072b898aca55aceb2a597",
+                "reference": "f973c8ad2a58e65f40d072b898aca55aceb2a597",
                 "shasum": ""
             },
             "require": {
@@ -2052,6 +2065,7 @@
                 "elasticsearch/elasticsearch": "~1.0|^2.0",
                 "instaclick/base-test-bundle": "~0.5",
                 "monolog/monolog": "~1.8",
+                "phpunit/phpunit": "^4.8",
                 "symfony/console": "~2.4",
                 "symfony/proxy-manager-bridge": "~2.4"
             },
@@ -2111,7 +2125,7 @@
                 "domain-driven design",
                 "event sourcing"
             ],
-            "time": "2016-06-14 20:42:04"
+            "time": "2016-08-31 09:20:59"
         },
         {
             "name": "broadway/uuid-generator",
@@ -2368,35 +2382,35 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v1.11.5",
+            "version": "v1.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "d3d08b76753092a232a4d8c3b94095ac06898719"
+                "reference": "78a820c16d13f593303511461eefa939502fb2de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/d3d08b76753092a232a4d8c3b94095ac06898719",
-                "reference": "d3d08b76753092a232a4d8c3b94095ac06898719",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/78a820c16d13f593303511461eefa939502fb2de",
+                "reference": "78a820c16d13f593303511461eefa939502fb2de",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.6",
-                "sebastian/diff": "~1.1",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/event-dispatcher": "~2.1|~3.0",
-                "symfony/filesystem": "~2.1|~3.0",
-                "symfony/finder": "~2.1|~3.0",
-                "symfony/process": "~2.3|~3.0",
-                "symfony/stopwatch": "~2.5|~3.0"
+                "php": "^5.3.6 || >=7.0 <7.2",
+                "sebastian/diff": "^1.1",
+                "symfony/console": "^2.3 || ^3.0",
+                "symfony/event-dispatcher": "^2.1 || ^3.0",
+                "symfony/filesystem": "^2.1 || ^3.0",
+                "symfony/finder": "^2.1 || ^3.0",
+                "symfony/process": "^2.3 || ^3.0",
+                "symfony/stopwatch": "^2.5 || ^3.0"
             },
             "conflict": {
                 "hhvm": "<3.9"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.5|^5",
-                "satooshi/php-coveralls": "^0.7.1"
+                "satooshi/php-coveralls": "^1.0"
             },
             "bin": [
                 "php-cs-fixer"
@@ -2422,7 +2436,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-07-06 22:49:35"
+            "time": "2016-10-30 12:07:10"
         },
         {
             "name": "guzzle/guzzle",
@@ -2718,16 +2732,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.5.1",
+            "version": "1.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "a8773992b362b58498eed24bf85005f363c34771"
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/a8773992b362b58498eed24bf85005f363c34771",
-                "reference": "a8773992b362b58498eed24bf85005f363c34771",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/399c1f9781e222f6eb6cc238796f5200d1b7f108",
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108",
                 "shasum": ""
             },
             "require": {
@@ -2756,7 +2770,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2015-11-20 12:04:31"
+            "time": "2016-10-31 17:19:45"
         },
         {
             "name": "pdepend/pdepend",
@@ -2854,16 +2868,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
                 "shasum": ""
             },
             "require": {
@@ -2895,7 +2909,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-10 09:48:41"
+            "time": "2016-09-30 07:12:33"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3560,16 +3574,16 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.4.1",
+            "version": "3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "b4fe3b7387cb323fd15ad5837cae992422c9fa5c"
+                "reference": "a07797b986671b0dc823885a81d5e3516b931599"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/b4fe3b7387cb323fd15ad5837cae992422c9fa5c",
-                "reference": "b4fe3b7387cb323fd15ad5837cae992422c9fa5c",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/a07797b986671b0dc823885a81d5e3516b931599",
+                "reference": "a07797b986671b0dc823885a81d5e3516b931599",
                 "shasum": ""
             },
             "require": {
@@ -3587,7 +3601,7 @@
                 "jakub-onderka/php-parallel-lint": "^0.9.0",
                 "mockery/mockery": "^0.9.4",
                 "moontoast/math": "^1.1",
-                "phpunit/phpunit": "^4.7|^5.0",
+                "phpunit/phpunit": "^4.7|>=5.0 <5.4",
                 "satooshi/php-coveralls": "^0.6.1",
                 "squizlabs/php_codesniffer": "^2.3"
             },
@@ -3636,7 +3650,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2016-04-24 00:30:41"
+            "time": "2016-10-02 15:51:17"
         },
         {
             "name": "rmiller/caser",
@@ -3944,23 +3958,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -3990,7 +4004,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-08-18 05:49:44"
         },
         {
             "name": "sebastian/exporter",
@@ -4296,16 +4310,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
+                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
                 "shasum": ""
             },
             "require": {
@@ -4370,32 +4384,33 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-05-30 22:24:32"
+            "time": "2016-09-01 23:53:02"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde"
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
-                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3|^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
@@ -4419,7 +4434,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2015-08-24 13:29:44"
+            "time": "2016-08-09 15:02:57"
         }
     ],
     "aliases": [],

--- a/spec/CodeGenerator/PhpParser/ClassGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/ClassGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/MethodFactorySpec.php
+++ b/spec/CodeGenerator/PhpParser/MethodFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser;
 
 use NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model\AggregateRootIdGetterGenerator;

--- a/spec/CodeGenerator/PhpParser/Methods/Broadway/Model/AggregateRootIdGetterGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/Broadway/Model/AggregateRootIdGetterGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/Broadway/Model/CreateGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/Broadway/Model/CreateGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/Broadway/Model/ReadModelIdGetterGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/Broadway/Model/ReadModelIdGetterGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/Broadway/Model/RepositoryConstructorGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/Broadway/Model/RepositoryConstructorGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/ConstructorGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/ConstructorGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/DeserializeGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/DeserializeGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/GetterGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/GetterGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/PhpSpec/InitializableGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/PhpSpec/InitializableGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods\PhpSpec;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/PhpSpec/LetGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/PhpSpec/LetGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods\PhpSpec;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/SerializeGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/SerializeGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/ToStringGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/ToStringGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParser/Methods/UuidCreateGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParser/Methods/UuidCreateGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use PhpParser\BuilderFactory;

--- a/spec/CodeGenerator/PhpParserGeneratorFactorySpec.php
+++ b/spec/CodeGenerator/PhpParserGeneratorFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/CodeGenerator/PhpParserGeneratorSpec.php
+++ b/spec/CodeGenerator/PhpParserGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\CodeGenerator;
 
 use NullDev\Skeleton\CodeGenerator\PhpParser\ClassGenerator;

--- a/spec/Definition/PHP/DefinitionFactorySpec.php
+++ b/spec/Definition/PHP/DefinitionFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model\AggregateRootIdGetterMethod;

--- a/spec/Definition/PHP/Methods/Broadway/Model/AggregateRootIdGetterMethodSpec.php
+++ b/spec/Definition/PHP/Methods/Broadway/Model/AggregateRootIdGetterMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model\AggregateRootIdGetterMethod;

--- a/spec/Definition/PHP/Methods/Broadway/Model/CreateMethodSpec.php
+++ b/spec/Definition/PHP/Methods/Broadway/Model/CreateMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/Broadway/Model/ReadModelIdGetterMethodSpec.php
+++ b/spec/Definition/PHP/Methods/Broadway/Model/ReadModelIdGetterMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/Broadway/Model/RepositoryConstructorMethodSpec.php
+++ b/spec/Definition/PHP/Methods/Broadway/Model/RepositoryConstructorMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Types\ClassType;

--- a/spec/Definition/PHP/Methods/ConstructorMethodSpec.php
+++ b/spec/Definition/PHP/Methods/ConstructorMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/DeserializeMethodSpec.php
+++ b/spec/Definition/PHP/Methods/DeserializeMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/GetterMethodSpec.php
+++ b/spec/Definition/PHP/Methods/GetterMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/PhpSpec/InitializableMethodSpec.php
+++ b/spec/Definition/PHP/Methods/PhpSpec/InitializableMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods\PhpSpec;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/PhpSpec/LetMethodSpec.php
+++ b/spec/Definition/PHP/Methods/PhpSpec/LetMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods\PhpSpec;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/SerializeMethodSpec.php
+++ b/spec/Definition/PHP/Methods/SerializeMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/ToStringMethodSpec.php
+++ b/spec/Definition/PHP/Methods/ToStringMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/Methods/UuidCreateMethodSpec.php
+++ b/spec/Definition/PHP/Methods/UuidCreateMethodSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/spec/Definition/PHP/ParameterSpec.php
+++ b/spec/Definition/PHP/ParameterSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP;
 
 use NullDev\Skeleton\Definition\PHP\Types\ClassType;

--- a/spec/Definition/PHP/Types/ClassTypeSpec.php
+++ b/spec/Definition/PHP/Types/ClassTypeSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types;
 
 use NullDev\Skeleton\Definition\PHP\Types\ClassType;

--- a/spec/Definition/PHP/Types/InterfaceTypeSpec.php
+++ b/spec/Definition/PHP/Types/InterfaceTypeSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types;
 
 use NullDev\Skeleton\Definition\PHP\Types\InterfaceType;

--- a/spec/Definition/PHP/Types/TraitTypeSpec.php
+++ b/spec/Definition/PHP/Types/TraitTypeSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types;
 
 use NullDev\Skeleton\Definition\PHP\Types\TraitType;

--- a/spec/Definition/PHP/Types/TypeDeclaration/ArrayTypeSpec.php
+++ b/spec/Definition/PHP/Types/TypeDeclaration/ArrayTypeSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 use NullDev\Skeleton\Definition\PHP\Types\Type;

--- a/spec/Definition/PHP/Types/TypeDeclaration/BoolTypeSpec.php
+++ b/spec/Definition/PHP/Types/TypeDeclaration/BoolTypeSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 use NullDev\Skeleton\Definition\PHP\Types\Type;

--- a/spec/Definition/PHP/Types/TypeDeclaration/FloatTypeSpec.php
+++ b/spec/Definition/PHP/Types/TypeDeclaration/FloatTypeSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 use NullDev\Skeleton\Definition\PHP\Types\Type;

--- a/spec/Definition/PHP/Types/TypeDeclaration/IntTypeSpec.php
+++ b/spec/Definition/PHP/Types/TypeDeclaration/IntTypeSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 use NullDev\Skeleton\Definition\PHP\Types\Type;

--- a/spec/Definition/PHP/Types/TypeDeclaration/StringTypeSpec.php
+++ b/spec/Definition/PHP/Types/TypeDeclaration/StringTypeSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 use NullDev\Skeleton\Definition\PHP\Types\Type;

--- a/spec/Definition/PHP/Types/TypeFactorySpec.php
+++ b/spec/Definition/PHP/Types/TypeFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Definition\PHP\Types;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/File/FileFactorySpec.php
+++ b/spec/File/FileFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\File;
 
 use Composer\Autoload\ClassLoader;

--- a/spec/File/FileGeneratorSpec.php
+++ b/spec/File/FileGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\File;
 
 use NullDev\Skeleton\CodeGenerator\PhpParserGenerator;

--- a/spec/File/FileResourceSpec.php
+++ b/spec/File/FileResourceSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\File;
 
 use Composer\Autoload\ClassLoader;

--- a/spec/Path/Psr0PathSpec.php
+++ b/spec/Path/Psr0PathSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Path;
 
 use Exception;

--- a/spec/Path/Psr4PathSpec.php
+++ b/spec/Path/Psr4PathSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Path;
 
 use Exception;

--- a/spec/Path/Readers/SourceCodePathReaderSpec.php
+++ b/spec/Path/Readers/SourceCodePathReaderSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Path\Readers;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Path/SpecPsr0PathSpec.php
+++ b/spec/Path/SpecPsr0PathSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Path;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Path/SpecPsr4PathSpec.php
+++ b/spec/Path/SpecPsr4PathSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Path;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Path/TestPsr0PathSpec.php
+++ b/spec/Path/TestPsr0PathSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Path;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Path/TestPsr4PathSpec.php
+++ b/spec/Path/TestPsr4PathSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Path;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Source/ClassSourceFactorySpec.php
+++ b/spec/Source/ClassSourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Source;
 
 use NullDev\Skeleton\Definition\PHP\Types\ClassType;

--- a/spec/Source/ImprovedClassSourceSpec.php
+++ b/spec/Source/ImprovedClassSourceSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\Source;
 
 use NullDev\Skeleton\Definition\PHP\Methods\ConstructorMethod;

--- a/spec/SourceFactory/Broadway/CommandSourceFactorySpec.php
+++ b/spec/SourceFactory/Broadway/CommandSourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/spec/SourceFactory/Broadway/EventSourceFactorySpec.php
+++ b/spec/SourceFactory/Broadway/EventSourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/spec/SourceFactory/Broadway/EventSourcedAggregateRootSourceFactorySpec.php
+++ b/spec/SourceFactory/Broadway/EventSourcedAggregateRootSourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/spec/SourceFactory/Broadway/EventSourcingRepositorySourceFactorySpec.php
+++ b/spec/SourceFactory/Broadway/EventSourcingRepositorySourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/spec/SourceFactory/Broadway/ReadEntitySourceFactorySpec.php
+++ b/spec/SourceFactory/Broadway/ReadEntitySourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/spec/SourceFactory/Broadway/ReadProjectorSourceFactorySpec.php
+++ b/spec/SourceFactory/Broadway/ReadProjectorSourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/spec/SourceFactory/Broadway/ReadRepositorySourceFactorySpec.php
+++ b/spec/SourceFactory/Broadway/ReadRepositorySourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/spec/SourceFactory/UuidIdentitySourceFactorySpec.php
+++ b/spec/SourceFactory/UuidIdentitySourceFactorySpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SourceFactory;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/spec/SpecGenerator/SpecGeneratorSpec.php
+++ b/spec/SpecGenerator/SpecGeneratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace spec\NullDev\Skeleton\SpecGenerator;
 
 use NullDev\Skeleton\Definition\PHP\Types\ClassType;

--- a/src/CodeGenerator/PhpParser/ClassGenerator.php
+++ b/src/CodeGenerator/PhpParser/ClassGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser;
 
 use NullDev\Skeleton\Definition\PHP\Parameter;

--- a/src/CodeGenerator/PhpParser/MethodFactory.php
+++ b/src/CodeGenerator/PhpParser/MethodFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser;
 
 use NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model\AggregateRootIdGetterGenerator;

--- a/src/CodeGenerator/PhpParser/Methods/Broadway/Model/AggregateRootIdGetterGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/Broadway/Model/AggregateRootIdGetterGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model\AggregateRootIdGetterMethod;

--- a/src/CodeGenerator/PhpParser/Methods/Broadway/Model/CreateGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/Broadway/Model/CreateGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model\CreateMethod;

--- a/src/CodeGenerator/PhpParser/Methods/Broadway/Model/ReadModelIdGetterGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/Broadway/Model/ReadModelIdGetterGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model\ReadModelIdGetterMethod;

--- a/src/CodeGenerator/PhpParser/Methods/Broadway/Model/RepositoryConstructorGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/Broadway/Model/RepositoryConstructorGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model\RepositoryConstructorMethod;

--- a/src/CodeGenerator/PhpParser/Methods/ConstructorGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/ConstructorGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\ConstructorMethod;

--- a/src/CodeGenerator/PhpParser/Methods/DeserializeGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/DeserializeGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\DeserializeMethod;

--- a/src/CodeGenerator/PhpParser/Methods/GetterGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/GetterGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\GetterMethod;

--- a/src/CodeGenerator/PhpParser/Methods/PhpSpec/InitializableGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/PhpSpec/InitializableGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods\PhpSpec;
 
 use NullDev\Skeleton\Definition\PHP\Methods\PhpSpec\InitializableMethod;

--- a/src/CodeGenerator/PhpParser/Methods/PhpSpec/LetGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/PhpSpec/LetGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods\PhpSpec;
 
 use NullDev\Skeleton\Definition\PHP\Methods\PhpSpec\LetMethod;

--- a/src/CodeGenerator/PhpParser/Methods/SerializeGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/SerializeGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\SerializeMethod;

--- a/src/CodeGenerator/PhpParser/Methods/ToStringGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/ToStringGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\ToStringMethod;

--- a/src/CodeGenerator/PhpParser/Methods/UuidCreateGenerator.php
+++ b/src/CodeGenerator/PhpParser/Methods/UuidCreateGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator\PhpParser\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Methods\UuidCreateMethod;

--- a/src/CodeGenerator/PhpParserGenerator.php
+++ b/src/CodeGenerator/PhpParserGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator;
 
 use NullDev\Skeleton\CodeGenerator\PhpParser\ClassGenerator;

--- a/src/CodeGenerator/PhpParserGeneratorFactory.php
+++ b/src/CodeGenerator/PhpParserGeneratorFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\CodeGenerator;
 
 use NullDev\Skeleton\CodeGenerator\PhpParser\ClassGenerator;

--- a/src/Definition/PHP/DefinitionFactory.php
+++ b/src/Definition/PHP/DefinitionFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model\AggregateRootIdGetterMethod;

--- a/src/Definition/PHP/Methods/Broadway/Model/AggregateRootIdGetterMethod.php
+++ b/src/Definition/PHP/Methods/Broadway/Model/AggregateRootIdGetterMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/src/Definition/PHP/Methods/Broadway/Model/CreateMethod.php
+++ b/src/Definition/PHP/Methods/Broadway/Model/CreateMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/src/Definition/PHP/Methods/Broadway/Model/ReadModelIdGetterMethod.php
+++ b/src/Definition/PHP/Methods/Broadway/Model/ReadModelIdGetterMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/src/Definition/PHP/Methods/Broadway/Model/RepositoryConstructorMethod.php
+++ b/src/Definition/PHP/Methods/Broadway/Model/RepositoryConstructorMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/src/Definition/PHP/Methods/ConstructorMethod.php
+++ b/src/Definition/PHP/Methods/ConstructorMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods;
 
 class ConstructorMethod implements Method

--- a/src/Definition/PHP/Methods/DeserializeMethod.php
+++ b/src/Definition/PHP/Methods/DeserializeMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Parameter;

--- a/src/Definition/PHP/Methods/GetterMethod.php
+++ b/src/Definition/PHP/Methods/GetterMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Parameter;

--- a/src/Definition/PHP/Methods/Method.php
+++ b/src/Definition/PHP/Methods/Method.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods;
 
 interface Method

--- a/src/Definition/PHP/Methods/PhpSpec/InitializableMethod.php
+++ b/src/Definition/PHP/Methods/PhpSpec/InitializableMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods\PhpSpec;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/src/Definition/PHP/Methods/PhpSpec/LetMethod.php
+++ b/src/Definition/PHP/Methods/PhpSpec/LetMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods\PhpSpec;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Method;

--- a/src/Definition/PHP/Methods/SerializeMethod.php
+++ b/src/Definition/PHP/Methods/SerializeMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Source\ImprovedClassSource;

--- a/src/Definition/PHP/Methods/ToStringMethod.php
+++ b/src/Definition/PHP/Methods/ToStringMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Parameter;

--- a/src/Definition/PHP/Methods/UuidCreateMethod.php
+++ b/src/Definition/PHP/Methods/UuidCreateMethod.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Methods;
 
 use NullDev\Skeleton\Definition\PHP\Types\ClassType;

--- a/src/Definition/PHP/Parameter.php
+++ b/src/Definition/PHP/Parameter.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP;
 
 use NullDev\Skeleton\Definition\PHP\Types\Type;

--- a/src/Definition/PHP/Types/ClassType.php
+++ b/src/Definition/PHP/Types/ClassType.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types;
 
 class ClassType extends ConceptName

--- a/src/Definition/PHP/Types/ConceptName.php
+++ b/src/Definition/PHP/Types/ConceptName.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types;
 
 abstract class ConceptName implements Importable, Type

--- a/src/Definition/PHP/Types/Importable.php
+++ b/src/Definition/PHP/Types/Importable.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types;
 
 interface Importable

--- a/src/Definition/PHP/Types/InterfaceType.php
+++ b/src/Definition/PHP/Types/InterfaceType.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types;
 
 class InterfaceType extends ConceptName

--- a/src/Definition/PHP/Types/TraitType.php
+++ b/src/Definition/PHP/Types/TraitType.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types;
 
 class TraitType extends ConceptName

--- a/src/Definition/PHP/Types/Type.php
+++ b/src/Definition/PHP/Types/Type.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types;
 
 interface Type

--- a/src/Definition/PHP/Types/TypeDeclaration/ArrayType.php
+++ b/src/Definition/PHP/Types/TypeDeclaration/ArrayType.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 class ArrayType implements TypeDeclaration

--- a/src/Definition/PHP/Types/TypeDeclaration/BoolType.php
+++ b/src/Definition/PHP/Types/TypeDeclaration/BoolType.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 class BoolType implements TypeDeclaration

--- a/src/Definition/PHP/Types/TypeDeclaration/FloatType.php
+++ b/src/Definition/PHP/Types/TypeDeclaration/FloatType.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 class FloatType implements TypeDeclaration

--- a/src/Definition/PHP/Types/TypeDeclaration/IntType.php
+++ b/src/Definition/PHP/Types/TypeDeclaration/IntType.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 class IntType implements TypeDeclaration

--- a/src/Definition/PHP/Types/TypeDeclaration/StringType.php
+++ b/src/Definition/PHP/Types/TypeDeclaration/StringType.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 class StringType implements TypeDeclaration

--- a/src/Definition/PHP/Types/TypeDeclaration/TypeDeclaration.php
+++ b/src/Definition/PHP/Types/TypeDeclaration/TypeDeclaration.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration;
 
 use NullDev\Skeleton\Definition\PHP\Types\Type;

--- a/src/Definition/PHP/Types/TypeFactory.php
+++ b/src/Definition/PHP/Types/TypeFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Definition\PHP\Types;
 
 use NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\ArrayType;

--- a/src/File/FileFactory.php
+++ b/src/File/FileFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\File;
 
 use Composer\Autoload\ClassLoader;

--- a/src/File/FileGenerator.php
+++ b/src/File/FileGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\File;
 
 use NullDev\Skeleton\CodeGenerator\PhpParserGenerator;

--- a/src/File/FileResource.php
+++ b/src/File/FileResource.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\File;
 
 use Composer\Autoload\ClassLoader;

--- a/src/Path/Path.php
+++ b/src/Path/Path.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Path;
 
 interface Path

--- a/src/Path/Psr0Path.php
+++ b/src/Path/Psr0Path.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Path;
 
 use Exception;

--- a/src/Path/Psr4Path.php
+++ b/src/Path/Psr4Path.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Path;
 
 use Exception;

--- a/src/Path/Readers/SourceCodePathReader.php
+++ b/src/Path/Readers/SourceCodePathReader.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Path\Readers;
 
 use hanneskod\classtools\Iterator\ClassIterator;

--- a/src/Path/SpecPsr0Path.php
+++ b/src/Path/SpecPsr0Path.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Path;
 
 class SpecPsr0Path extends Psr0Path

--- a/src/Path/SpecPsr4Path.php
+++ b/src/Path/SpecPsr4Path.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Path;
 
 class SpecPsr4Path extends Psr4Path

--- a/src/Path/TestPsr0Path.php
+++ b/src/Path/TestPsr0Path.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Path;
 
 class TestPsr0Path extends Psr0Path

--- a/src/Path/TestPsr4Path.php
+++ b/src/Path/TestPsr4Path.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Path;
 
 class TestPsr4Path extends Psr4Path

--- a/src/Source/ClassSourceFactory.php
+++ b/src/Source/ClassSourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Source;
 
 use NullDev\Skeleton\Definition\PHP\Types\ClassType;

--- a/src/Source/ImprovedClassSource.php
+++ b/src/Source/ImprovedClassSource.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\Source;
 
 use NullDev\Skeleton\Definition\PHP\Methods\ConstructorMethod;
@@ -67,9 +68,7 @@ class ImprovedClassSource
         return $this->classType->getFullName();
     }
 
-    //
     //-----     Parent     -----
-    //
 
     public function addParent(ClassType $parent)
     {
@@ -103,9 +102,7 @@ class ImprovedClassSource
         return $this->getParent()->getName();
     }
 
-    //
     //-----     Interfaces     -----
-    //
 
     public function addInterface(InterfaceType $interface)
     {
@@ -129,9 +126,7 @@ class ImprovedClassSource
         return $this->interfaces;
     }
 
-    //
     //-----     Traits     -----
-    //
 
     public function addTrait(TraitType $trait)
     {
@@ -155,9 +150,8 @@ class ImprovedClassSource
         return $this->traits;
     }
 
-    //
     //-----     ConstructorMethod     -----
-    //
+
     public function hasConstructorMethod()
     {
         if (null === $this->constructor) {
@@ -205,9 +199,7 @@ class ImprovedClassSource
         return $this->constructor->getMethodParameters();
     }
 
-    //
     //-----     Properties     -----
-    //
 
     public function addProperty(Parameter $property)
     {
@@ -219,9 +211,7 @@ class ImprovedClassSource
         return $this->properties;
     }
 
-    //
     //-----     Methods     -----
-    //
 
     public function addGetterMethod(Parameter $parameter)
     {
@@ -238,9 +228,7 @@ class ImprovedClassSource
         return $this->methods;
     }
 
-    //
     //-----     Import     -----
-    //
 
     public function addImport(Type $import)
     {

--- a/src/SourceFactory/Broadway/CommandSourceFactory.php
+++ b/src/SourceFactory/Broadway/CommandSourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/src/SourceFactory/Broadway/EventSourceFactory.php
+++ b/src/SourceFactory/Broadway/EventSourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/src/SourceFactory/Broadway/EventSourcedAggregateRootSourceFactory.php
+++ b/src/SourceFactory/Broadway/EventSourcedAggregateRootSourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/src/SourceFactory/Broadway/EventSourcingRepositorySourceFactory.php
+++ b/src/SourceFactory/Broadway/EventSourcingRepositorySourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/src/SourceFactory/Broadway/ReadEntitySourceFactory.php
+++ b/src/SourceFactory/Broadway/ReadEntitySourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/src/SourceFactory/Broadway/ReadProjectorSourceFactory.php
+++ b/src/SourceFactory/Broadway/ReadProjectorSourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/src/SourceFactory/Broadway/ReadRepositorySourceFactory.php
+++ b/src/SourceFactory/Broadway/ReadRepositorySourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory\Broadway;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/src/SourceFactory/SourceFactory.php
+++ b/src/SourceFactory/SourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory;
 
 interface SourceFactory

--- a/src/SourceFactory/UuidIdentitySourceFactory.php
+++ b/src/SourceFactory/UuidIdentitySourceFactory.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SourceFactory;
 
 use NullDev\Skeleton\Definition\PHP\DefinitionFactory;

--- a/src/SpecGenerator/SpecGenerator.php
+++ b/src/SpecGenerator/SpecGenerator.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace NullDev\Skeleton\SpecGenerator;
 
 use NullDev\Skeleton\Definition\PHP\Methods\Broadway\Model\RepositoryConstructorMethod;

--- a/tests/CodeGenerator/BaseCodeGeneratorTest.php
+++ b/tests/CodeGenerator/BaseCodeGeneratorTest.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace tests\NullDev\Skeleton\Output\PHP;
 
 use Mockery as m;

--- a/tests/CodeGenerator/PhpParserGeneratorTest.php
+++ b/tests/CodeGenerator/PhpParserGeneratorTest.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace tests\NullDev\Skeleton\Output\PHP;
 
 use Mockery as m;

--- a/tests/CodeGenerator/PhpParserSpecGeneratorTest.php
+++ b/tests/CodeGenerator/PhpParserSpecGeneratorTest.php
@@ -1,6 +1,7 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
+
 namespace tests\NullDev\Skeleton\Output\PHP;
 
 use Mockery as m;


### PR DESCRIPTION
Packages updated:
- nikic/php-parser (v2.1.0->v2.1.1)
- symfony/yaml (v3.1.2->v3.1.6)
- symfony/process (v3.1.2->v3.1.6)
- psr/log (1.0.0->1.0.2)
- symfony/debug (v3.1.2->v3.1.6)
- symfony/console (v3.1.2->v3.1.6)
- symfony/translation (v3.1.2->v3.1.6)
- symfony/templating (v3.1.2->v3.1.6)
- symfony/stopwatch (v3.1.2->v3.1.6)
- symfony/security-core (v3.1.2->v3.1.6)
- paragonie/random_compat (v2.0.2->v2.0.3)
- symfony/security-csrf (v3.1.2->v3.1.6)
- symfony/routing (v3.1.2->v3.1.6)
- symfony/http-foundation (v3.1.2->v3.1.6)
- symfony/event-dispatcher (v3.1.2->v3.1.6)
- symfony/http-kernel (v3.1.2->v3.1.6)
- symfony/finder (v3.1.2->v3.1.6)
- symfony/filesystem (v3.1.2->v3.1.6)
- symfony/dependency-injection (v3.1.2->v3.1.6)
- symfony/config (v3.1.2->v3.1.6)
- symfony/class-loader (v3.1.2->v3.1.6)
- psr/cache (1.0.0->1.0.1)
- symfony/cache (v3.1.2->v3.1.6)
- symfony/asset (v3.1.2->v3.1.6)
- doctrine/cache (v1.6.0->v1.6.1)
- doctrine/annotations (v1.2.7->v1.3.0)
- symfony/framework-bundle (v3.1.2->v3.1.6)
- sensio/generator-bundle (v3.0.7->v3.0.11)
- squizlabs/php_codesniffer (2.6.1->2.7.0)
- friendsofphp/php-cs-fixer (v1.11.5->v1.12.3)
- ramsey/uuid (3.4.1->3.5.1)
- beberlei/assert (v2.5.1->v2.6.6)
- myclabs/deep-copy (1.5.1->1.5.5)
- sebastian/environment (1.3.7->1.3.8)
- webmozart/assert (1.0.2->1.1.0)
- phpdocumentor/reflection-docblock (3.1.0->3.1.1)
- broadway/broadway dev-master (18d289a => f973c8a)